### PR TITLE
Python 3 instead of Python 2?

### DIFF
--- a/src/getting-started/build-environment.md
+++ b/src/getting-started/build-environment.md
@@ -41,7 +41,7 @@ rollup ./main.js --format iife --file ./pkg/bundle.js
 Feel free to use your preferred server. Here we use a simple python server to serve to [http://\[::1\]:8000](http://[::1]:8000).
 
 ```bash
-python -m SimpleHTTPServer 8000
+python -m http.server 8000
 ```
 
 #### Supported Targets


### PR DESCRIPTION
This is a Python 2 command

    python -m SimpleHTTPServer 8000

Would you rather have Python 3?

    python -m http.server 8000

Alternatively, you could be explicit with 

    python3 -m http.server 8000